### PR TITLE
Update qreg_example.jl

### DIFF
--- a/examples/qreg_example.jl
+++ b/examples/qreg_example.jl
@@ -1,4 +1,4 @@
-using GLM, QuantileRegressions, CSV, Winston, StatsBase
+using GLM, QuantileRegressions, CSV, Winston, StatsBase, DataFrames
 
 # Load data
 url = "http://vincentarelbundock.github.io/Rdatasets/csv/quantreg/engel.csv"
@@ -18,7 +18,10 @@ PlotDF = DataFrame(
     Y = DataPlot[:,1],
     ols = ols[:,1],
     Ymin = DataPlot[:,1] - 1.96 * DataPlot[:,2],
-    Ymax = DataPlot[:,1] + 1.96 * DataPlot[:,2])
+    Ymax = DataPlot[:,1] + 1.96 * DataPlot[:,2],
+    YminLM = ols[:,1] - 1.96 * ols[:,2],
+    YmaxLM = ols[:,1] + 1.96 * ols[:,2]
+)
 
 x = PlotDF[:X]
 p = FramedPlot()
@@ -26,10 +29,12 @@ p = FramedPlot()
 βols = Curve(x, PlotDF[:ols] , "color", "red")
 ci_low  = Curve(x, PlotDF[:Ymin], "type" , "dash")
 ci_high = Curve(x, PlotDF[:Ymax], "type" , "dash")
+ci_lowLM  = Curve(x, PlotDF[:YminLM], "type" , "dash", "color", "red")
+ci_highLM = Curve(x, PlotDF[:YmaxLM], "type" , "dash", "color", "red")
 setattr(βτ,"label","β(τ)")
 setattr(βols, "label", "β(ols)")
 lgnd = Legend(.8,.2,[βτ, βols])
-add(p, βτ, βols, ci_low, ci_high, lgnd)
+add(p, βτ, βols, ci_low, ci_high, ci_lowLM, ci_highLM, lgnd)
 setattr(p, "title" , "Quantile regression: Food Expenditure ~ Income")
 setattr(p, "xlabel", "Quantiles")
 setattr(p, "ylabel", "Coefficient on Income")


### PR DESCRIPTION
Currently the example in the Readme has 95% confidence intervals for the quantile regression estimates, but not for the ols estimates. This PR adds the 95% CI for the OLS estimates. 