### PR TITLE
npqreg support for data that is too sparse for the bandwidth.

### DIFF
--- a/src/npqreg.jl
+++ b/src/npqreg.jl
@@ -13,9 +13,27 @@ function npqreg(y, x, tau, method=IP(); m=50, h=2, xrange=nothing)
 
         w = pdf.(Normal(), z./h)
         widx = findall(x-> x > eps(T), w)
+
         if length(widx) > 1
             # more than one observation with positive
             # weights, so we can estimate value and derivative
+            
+            # first we check that there is actually variation
+            # in the second column
+            variation = false
+            z1 = Z[widx[1], 2]
+            for j = 2:length(widx)
+                if Z[widx[j], 2] !== z1
+                    variation = true
+                    break
+                end
+            end
+            if !variation
+                ghat[i] = qreg_coef(y[widx], fill(1.0, length(widx), 1), tau, method)[1]
+                dghat[i] = NaN
+                continue
+            end
+
             w = w[widx]
             wy = w.*y[widx]
             wZ = w.*Z[widx, :]

--- a/test/npqreg.jl
+++ b/test/npqreg.jl
@@ -20,4 +20,6 @@ using QuantileRegressions, CSV
 	res = QuantileRegressions.npqreg([y[1]], [x[1]], 0.8; xrange=[x[1].+1], h=0.1)
 	@test isnan(res[2][1])
 	@test isnan(res[3][1])
+
+	@test all(QuantileRegressions.npqreg([1.0,2.0,4.0,5.0], [0.0,0.0,6.0,12.0], 0.3; h=0.001, xrange=[0.0,6.0,12.0])[2] .≈ [1.0, 4.0, 5.0])
 end


### PR DESCRIPTION
Pivoting in QR unfortunately allocates too much which results in too much GC.