### PR TITLE
Support StatsBase 0.34

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "QuantileRegressions"
 uuid = "c6596682-b856-542f-9fff-31404643e889"
-version = "0.1.10"
+version = "0.1.11"
 
 [deps]
 DataFrames = "a93c6f00-e57d-5684-b7b6-d8193f3e46c0"
@@ -12,7 +12,7 @@ StatsModels = "3eaba693-59b7-5ba5-a881-562e759f1c8d"
 [compat]
 DataFrames = "0.18, 0.19, 0.20, 0.21, 0.22, 1.0"
 Distributions = "0.20, 0.21, 0.22, 0.23, 0.24, 0.25"
-StatsBase = "0.30, 0.31, 0.32, 0.33"
+StatsBase = "0.30, 0.31, 0.32, 0.33, 0.34"
 StatsModels = "0.6, 0.7"
 julia = "1.3"
 


### PR DESCRIPTION
I noticed that QuantileRegressions.jl does not support StatsBase 0.34. There's no CompatHelper PR since apparently the CompatHelper workflow was disabled due to inactivity; I assume, in addition to this PR it would be good to re-enable the workflow.

BTW it seems that the last commit on the master branch which added support for StatsModels 0.7 is not released yet, see https://github.com/pkofod/QuantileRegressions.jl/issues/64#issuecomment-1732064068. I guess it's OK to update both StatsBase and StatsModels compatibilities in a single release.